### PR TITLE
Avoid build protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from distutils.command import build_py
-from distutils.command import clean
-from distutils import spawn
 import os
 import setuptools
 import subprocess
@@ -34,57 +31,6 @@ def _readme():
     with open("README") as f:
         return f.read()
 
-
-def build_proto(proto_path, include_path, out_path):
-    protoc = spawn.find_executable('protoc')
-    if protoc is None:
-        sys.stderr.write('Cannot find the protoc compiler in $PATH')
-        sys.exit(1)
-    if subprocess.call([protoc, '-I=%s' % include_path,
-                        '--python_out=%s' % out_path, proto_path]) != 0:
-        sys.stderr.write('Failed to compile %s' % proto_path)
-        sys.exit(1)
-
-
-class build_with_proto_py(build_py.build_py):
-    def run(self):
-        _PROTOBUF_PATH = 'src/midonetclient/topology/_protobuf'
-        try:
-            os.makedirs(_PROTOBUF_PATH)
-        except OSError as ose:
-            if ose.errno == os.errno.EEXIST:
-                pass
-        else:
-            with open(os.path.join(_PROTOBUF_PATH, '__init__.py'), 'a'):
-                pass
-        build_proto('../nsdb/src/main/proto/commons.proto',
-                    '../nsdb/src/main/proto',
-                    'src/midonetclient/topology/_protobuf')
-        build_proto('../nsdb/src/main/proto/topology_api.proto',
-                    '../nsdb/src/main/proto',
-                    'src/midonetclient/topology/_protobuf')
-        build_proto('../nsdb/src/main/proto/topology.proto',
-                    '../nsdb/src/main/proto',
-                    'src/midonetclient/topology/_protobuf')
-
-        # build testing protobuf
-        build_proto('src/tests/test.proto',
-                    'src',
-                    'src')
-
-        # Build the rest
-        build_py.build_py.run(self)
-
-
-class clean_even_proto(clean.clean):
-    def run(self):
-        for (dirpath, dirnames, filenames) in os.walk("."):
-            for filename in filenames:
-                filepath = os.path.join(dirpath, filename)
-                if (filepath.endswith("_pb2.py") or
-                        filepath.endswith("_pb2.pyc")):
-                    os.remove(filepath)
-        clean.clean.run(self)
 
 setuptools.setup(name=MODULE_NAME,
       version=__import__(MODULE_NAME).__version__,
@@ -108,8 +54,6 @@ setuptools.setup(name=MODULE_NAME,
       package_dir={"": SRC_DIR},
       packages=setuptools.find_packages(SRC_DIR, exclude=["tests"]),
       scripts=["src/bin/midonet-cli"],
-      cmdclass = {'clean': clean_even_proto,
-                  'build_py': build_with_proto_py},
       install_requires=[
           "httplib2",
           "webob",


### PR DESCRIPTION
setup.py does not need anymore the commands to build protobuf, since
they are generated inside the repo
